### PR TITLE
fix(docker-compose): increase gunicorn timeout to 120 seconds to prev…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   web:
     build: .
-    command: gunicorn server:app -w 4 -b 0.0.0.0:4200 --access-logfile - --error-logfile -
+    command: gunicorn server:app -w 4 -b 0.0.0.0:4200 --timeout 120 --access-logfile - --error-logfile -
     ports:
       - "4200:4200"
     volumes:


### PR DESCRIPTION
- increase gunicorn timeout to 120 seconds to prevent worker termination during long-running requests